### PR TITLE
support Chinese punctuation

### DIFF
--- a/escodegen/escodegen.py
+++ b/escodegen/escodegen.py
@@ -604,6 +604,12 @@ def escapeString(string):
         elif esutils.code.isLineTerminator(code) or code == 0x5c: # '\'
             result += escapeDisallowedCharacter(code)
             continue
+        elif (
+            0x3000 <= code <= 0x303F or  # 中文标点符号
+            0xFF00 <= code <= 0xFFEF     # 半角及全角标记
+        ):
+            result += chr(code)  # 直接保留字符形式
+            continue
         elif not esutils.code.isIdentifierPartES5(code) and (
                 json and code < 0x20 or # 'SP'
                 not json and not escapeless and (


### PR DESCRIPTION
您好我使用您的库进行 js 的 ast 和反转 ast 发现遇到问题

    js_code = r"""
        console.log('我，按钮');
    """
    options = {
        'unicode': False , # 禁用 Unicode 转义
        'escapeless': False  # 禁用 Unicode 转义
    }
    # ===== 第一步：解析 JS 为 AST =====
    ast = esprima.parseScript(js_code,options)

    regenerated_code = escodegen.generate(ast,options)

    print("原始代码：")
    print(js_code)
    print("\n反解后的代码：\n\n")
    print(regenerated_code)

我会得到如下结果

原始代码：

        console.log('我，按钮');
    

反解后的代码：


console.log('我\u16512按钮');



then i debug your code find

```
def escapeString(string):
    result = ''
    singleQuotes = 0
    doubleQuotes = 0
    
    for i in range(len(string)):
        code = ord(string[i])
        if code == 0x27: # "'"
            singleQuotes += 1
        elif code == 0x22: # '"'
            doubleQuotes += 1
        elif code == 0x2f and json: # '/'
            result += '\\'
        elif esutils.code.isLineTerminator(code) or code == 0x5c: # '\'
            result += escapeDisallowedCharacter(code)
            continue
        # elif (
        #         0x3000 <= code <= 0x303F or  # 中文标点符号
        #         0xFF00 <= code <= 0xFFEF     # 半角及全角标记
        #     ):
        #     result += chr(code)  # 直接保留字符形式
        #     continue
        elif not esutils.code.isIdentifierPartES5(code) and (
                json and code < 0x20 or # 'SP'
                not json and not escapeless and (
                    code < 0x20 or # 'SP'
                    code > 0x7e # '~'
                )):
            nextChar = ord(string[i + 1]) if i + 1 < len(string) else None
            result += escapeAllowedCharacter(code, nextChar)
            continue
        else:
            result += chr(code)  
```

你能帮我合并吗?
